### PR TITLE
Fixed get example notebooks from github

### DIFF
--- a/bootstrap/slave-bootstrap.sh
+++ b/bootstrap/slave-bootstrap.sh
@@ -32,9 +32,5 @@ aws s3 cp s3://jade-secrets/jade-secrets /usr/local/share/jade/jade-secrets
 # pull scientific environment image
 docker pull quay.io/informaticslab/atmossci-notebook
 
-# pull examples notebooks
-git clone git@github.com:met-office-lab/example-notebooks.git /usr/local/share/jade/example-notebooks/
-rm /usr/local/share/jade/example-notebooks/LICENSE
-
 # run config
 docker run -d --add-host "jupyterhub:${JUPYTERHUB_HOST}" swarm join --advertise=$(ifconfig eth0 | grep 'inet addr:' | cut -d: -f2 | awk '{ print $1}'):2375 consul://jupyterhub:8500

--- a/docker/notebook-slave/atmossci-notebook/start-singleuser.sh
+++ b/docker/notebook-slave/atmossci-notebook/start-singleuser.sh
@@ -1,6 +1,11 @@
 #!/bin/bash
 set -e
 
+# pull examples notebooks
+git clone git@github.com:met-office-lab/example-notebooks.git /usr/local/share/notebooks/Example\ Notebooks
+rm /usr/local/share/Example\ Notebooks/LICENSE
+
+# start single user server
 notebook_arg=""
 if [ -n "${NOTEBOOK_DIR:+x}" ]
 then


### PR DESCRIPTION
Previously examples were only being got when EC2 servers were restarted. Now they are got when each notebook server is started