### PR TITLE
Add environment variable for stack and propagate through to db mount point

### DIFF
--- a/bootstrap/bootstrap.sh
+++ b/bootstrap/bootstrap.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+export ENVIRONMENT=${environment}
+
 # install deps
 yum install -y git nfs-utils
 

--- a/docker/master/docker-compose.yml
+++ b/docker/master/docker-compose.yml
@@ -45,7 +45,7 @@ mysql:
   image: mysql:latest
   env_file: /usr/local/share/jade/jade-secrets
   volumes:
-    - /mnt/jade-notebooks/database:/var/lib/mysql
+    - /mnt/jade-notebooks/database/${ENVIRONMENT}:/var/lib/mysql
 
 swarm-master:
   restart: always

--- a/terraform/dask/environments/devel.tfvars
+++ b/terraform/dask/environments/devel.tfvars
@@ -1,3 +1,4 @@
+environment = "devel"
 dns = "devel.dask.informaticslab.co.uk"
 worker-name = "dev-dask-worker"
 scheduler-name = "dev-dask-scheduler"

--- a/terraform/dask/environments/production.tfvars
+++ b/terraform/dask/environments/production.tfvars
@@ -1,3 +1,4 @@
+environment = "production"
 dns = "dask.informaticslab.co.uk"
 worker-name = "dask-worker"
 scheduler-name = "dask-scheduler"

--- a/terraform/jupyter/environments/devel.tfvars
+++ b/terraform/jupyter/environments/devel.tfvars
@@ -1,3 +1,4 @@
+environment = "devel"
 dns = "devel.jupyter.informaticslab.co.uk"
 worker-name = "dev-jupyter-worker"
 master-name = "dev-jupyter-master"

--- a/terraform/jupyter/environments/production.tfvars
+++ b/terraform/jupyter/environments/production.tfvars
@@ -1,3 +1,4 @@
+environment = "production"
 dns = "jupyter.informaticslab.co.uk"
 worker-name = "jupyter-worker"
 master-name = "jupyter-master"

--- a/terraform/jupyter/jade-master.tf
+++ b/terraform/jupyter/jade-master.tf
@@ -1,4 +1,5 @@
 variable dns {}
+variable environment {}
 variable master-name {}
 variable host_env_file {}
 variable jade-secrets-file {}
@@ -9,6 +10,7 @@ data "template_file" "master-bootstrap" {
     vars = {
       host_env_file = "${var.host_env_file}"
       jade-secrets-file = "${var.jade-secrets-file}"
+      environment = "${var.environment}"
     }
 }
 


### PR DESCRIPTION
Currently both stacks are trying to use the same file path for the mysql database. Therefore we are experiencing problems when running both stacks.

This change tells the database to look at `/mnt/jade-notebooks/database/${ENVIRONMENT}` instead of `/mnt/jade-notebooks/database`. That variable has been created in the terraform files and propagated through the bootstrap script into the compose file.

For this to work both stacks must be stopped. Then the contents of `/mnt/jade-notebooks/database` must be moved and copied to `/mnt/jade-notebooks/database/devel` and `/mnt/jade-notebooks/database/production`. Then both stacks should start successfully.

Easiest way to do this is to stop production. Then ssh to devel and stop the containers. From there we will have access to the mount point and can copy the files. Then to test it works we should destroy the devel stack too. Then build them both again.