### PR TITLE
Monitoring

### DIFF
--- a/bootstrap/slave-bootstrap.sh
+++ b/bootstrap/slave-bootstrap.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 export JUPYTERHUB_HOST="${jademaster_private_ip}"
+export IP_ADDR=$(ifconfig eth0 | grep 'inet addr:' | cut -d: -f2 | awk '{ print $1}')
 
 # install deps
 yum install -y git nfs-utils
@@ -36,4 +37,4 @@ aws s3 cp s3://jade-secrets/jade-secrets /usr/local/share/jade/jade-secrets
 docker pull quay.io/informaticslab/asn-serve
 
 # run config
-docker run -d --add-host "jupyterhub:${jademaster_private_ip}" swarm join --advertise=$(ifconfig eth0 | grep 'inet addr:' | cut -d: -f2 | awk '{ print $1}'):2375 consul://jupyterhub:8500
+/usr/local/bin/docker-compose -f /usr/local/share/jade/docker/slave/docker-compose.yml up -d

--- a/docker/master/docker-compose.yml
+++ b/docker/master/docker-compose.yml
@@ -62,3 +62,18 @@ consul:
   ports:
     - 8500:8500
   command: "-server -bootstrap"
+
+telegraf:
+  restart: always
+  image: telegraf:latest
+  environment:
+    HOST_PROC: /rootfs/proc
+    HOST_SYS: /rootfs/sys
+    HOST_ETC: /rootfs/etc
+  hostname: jade-master-${ENVIRONMENT}
+  volumes:
+   - /usr/local/share/jade/docker/master/telegraf.conf:/etc/telegraf/telegraf.conf:ro
+   - /var/run/docker.sock:/var/run/docker.sock:ro
+   - /sys:/rootfs/sys:ro
+   - /proc:/rootfs/proc:ro
+   - /etc:/rootfs/etc:ro

--- a/docker/master/telegraf.conf
+++ b/docker/master/telegraf.conf
@@ -1,0 +1,45 @@
+[global_tags]
+
+[agent]
+  interval = "10s"
+  round_interval = true
+  metric_batch_size = 1000
+  metric_buffer_limit = 10000
+  collection_jitter = "0s"
+  flush_interval = "10s"
+  flush_jitter = "0s"
+  debug = false
+  quiet = false
+  hostname = ""
+  omit_hostname = false
+
+[[outputs.influxdb]]
+  urls = ["http://monitor.internal.informaticslab.co.uk:8086"]
+  database = "telegraf"
+  precision = "s"
+  retention_policy = "default"
+  write_consistency = "any"
+  timeout = "5s"
+
+[[inputs.cpu]]
+  percpu = true
+  totalcpu = true
+  fielddrop = ["time_*"]
+
+[[inputs.disk]]
+  ignore_fs = ["tmpfs", "devtmpfs"]
+
+[[inputs.diskio]]
+
+[[inputs.kernel]]
+
+[[inputs.mem]]
+
+[[inputs.processes]]
+
+[[inputs.swap]]
+
+[[inputs.system]]
+
+[[inputs.docker]]
+  endpoint = "unix:///var/run/docker.sock"

--- a/docker/slave/docker-compose.yml
+++ b/docker/slave/docker-compose.yml
@@ -1,0 +1,21 @@
+swarm:
+  restart: always
+  image: swarm
+  extra-hosts:
+    - "jupyterhub:${JUPYTERHUB_HOST}"
+  command: "join --advertise=${IP_ADDR}:2375 consul://jupyterhub:8500"
+
+telegraf:
+  restart: always
+  image: telegraf:latest
+  environment:
+    HOST_PROC: /rootfs/proc
+    HOST_SYS: /rootfs/sys
+    HOST_ETC: /rootfs/etc
+  hostname: jade-slave-${ENVIRONMENT}
+  volumes:
+   - /usr/local/share/jade/docker/slave/telegraf.conf:/etc/telegraf/telegraf.conf:ro
+   - /var/run/docker.sock:/var/run/docker.sock:ro
+   - /sys:/rootfs/sys:ro
+   - /proc:/rootfs/proc:ro
+   - /etc:/rootfs/etc:ro

--- a/docker/slave/telegraf.conf
+++ b/docker/slave/telegraf.conf
@@ -1,0 +1,45 @@
+[global_tags]
+
+[agent]
+  interval = "10s"
+  round_interval = true
+  metric_batch_size = 1000
+  metric_buffer_limit = 10000
+  collection_jitter = "0s"
+  flush_interval = "10s"
+  flush_jitter = "0s"
+  debug = false
+  quiet = false
+  hostname = ""
+  omit_hostname = false
+
+[[outputs.influxdb]]
+  urls = ["http://monitor.internal.informaticslab.co.uk:8086"]
+  database = "telegraf"
+  precision = "s"
+  retention_policy = "default"
+  write_consistency = "any"
+  timeout = "5s"
+
+[[inputs.cpu]]
+  percpu = true
+  totalcpu = true
+  fielddrop = ["time_*"]
+
+[[inputs.disk]]
+  ignore_fs = ["tmpfs", "devtmpfs"]
+
+[[inputs.diskio]]
+
+[[inputs.kernel]]
+
+[[inputs.mem]]
+
+[[inputs.processes]]
+
+[[inputs.swap]]
+
+[[inputs.system]]
+
+[[inputs.docker]]
+  endpoint = "unix:///var/run/docker.sock"

--- a/terraform/jupyter/jade-master.tf
+++ b/terraform/jupyter/jade-master.tf
@@ -67,6 +67,16 @@ resource "aws_security_group_rule" "allow_from_slave" {
     source_security_group_id = "${aws_security_group.jadeslave.id}"
 }
 
+resource "aws_security_group_rule" "allow_master_monitoring" {
+    type = "ingress"
+    from_port = 0
+    to_port = 0
+    protocol = "-1"
+
+    security_group_id = "sg-11e34c75" # Magic id for persistent monitoring stack
+    source_security_group_id = "${aws_security_group.jademaster.id}"
+}
+
 resource "aws_route53_record" "jupyter" {
   zone_id = "Z3USS9SVLB2LY1"
   name = "${var.dns}."

--- a/terraform/jupyter/jade-slave.tf
+++ b/terraform/jupyter/jade-slave.tf
@@ -30,6 +30,16 @@ resource "aws_security_group_rule" "allow_from_master" {
     source_security_group_id = "${aws_security_group.jademaster.id}"
 }
 
+resource "aws_security_group_rule" "allow_slave_monitoring" {
+    type = "ingress"
+    from_port = 0
+    to_port = 0
+    protocol = "-1"
+
+    security_group_id = "sg-11e34c75" # Magic id for persistent monitoring stack
+    source_security_group_id = "${aws_security_group.jadeslave.id}"
+}
+
 resource "aws_launch_configuration" "notebook-slaves" {
     name = "${var.worker-name}"
     image_id = "ami-f9dd458a"


### PR DESCRIPTION
Changes:
 * Run a [telegraf](https://www.influxdata.com/time-series-platform/telegraf/) container on the jupyter master and slaves
 * Switch to `docker-compose` on the slaves as there is now more than one container
 * Add security group rules to the persistent monitoring group to allow traffic from jade

TODO:
 * Monitor dask workers